### PR TITLE
Register the browserify brfs transform.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "node": ">= 0.10.0",
     "npm": ">= 1.0.0"
   },
+  "browserify": {
+    "transform": [ "brfs" ]
+  },
   "dependencies": {
     "unicode-trie": "^0.3.1"
   },


### PR DESCRIPTION
Adding the browserify transform registration is needed for libraries depending on precis-js to be able to build correctly.
